### PR TITLE
fix: replace unwrap() with proper error handling in dependency_graph

### DIFF
--- a/src/dependency_graph/mod.rs
+++ b/src/dependency_graph/mod.rs
@@ -31,7 +31,9 @@ pub fn build_dependency_graph(
     metadata: Metadata,
     config: DependencyGraphBuildConfigs,
 ) -> Result<Graph, Error> {
-    let resolve = metadata.resolve.unwrap();
+    let resolve = metadata
+        .resolve
+        .ok_or_else(|| anyhow!("cargo metadata did not return dependency resolve information"))?;
 
     let mut graph = Graph {
         graph: StableGraph::new(),


### PR DESCRIPTION
## Summary
- `src/dependency_graph/mod.rs` の `metadata.resolve.unwrap()` を `ok_or_else` に置換
- `find_package` 内の `it.next().unwrap()` は #98 で関数ごと削除済みのため対象外

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — 全テスト通過

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)