### PR TITLE
refactor: add ReturnStatus::merge to deduplicate violation logic

### DIFF
--- a/src/dependency_graph/tree.rs
+++ b/src/dependency_graph/tree.rs
@@ -187,11 +187,7 @@ fn print_package<'a>(
     };
 
     if !new {
-        return match (is_violation, parent_return_status) {
-            (true, _) => ReturnStatus::Violation,
-            (false, ReturnStatus::Violation) => ReturnStatus::Violation,
-            _ => ReturnStatus::NoViolation,
-        };
+        return parent_return_status.merge(is_violation);
     }
 
     for kind in &[
@@ -199,11 +195,7 @@ fn print_package<'a>(
         DependencyKind::Build,
         DependencyKind::Development,
     ] {
-        let current_return_status = match (is_violation, parent_return_status.clone()) {
-            (true, _) => ReturnStatus::Violation,
-            (false, ReturnStatus::Violation) => ReturnStatus::Violation,
-            _ => ReturnStatus::NoViolation,
-        };
+        let current_return_status = parent_return_status.clone().merge(is_violation);
 
         let result = print_dependencies(
             graph,
@@ -225,11 +217,7 @@ fn print_package<'a>(
         }
     }
 
-    match (is_violation, parent_return_status) {
-        (true, _) => ReturnStatus::Violation,
-        (false, ReturnStatus::Violation) => ReturnStatus::Violation,
-        _ => ReturnStatus::NoViolation,
-    }
+    parent_return_status.merge(is_violation)
 }
 
 // TODO: lint回避の精査
@@ -318,9 +306,5 @@ fn print_dependencies<'a>(
         }
     }
 
-    match (is_violation, parent_return_status) {
-        (true, _) => ReturnStatus::Violation,
-        (false, ReturnStatus::Violation) => ReturnStatus::Violation,
-        _ => ReturnStatus::NoViolation,
-    }
+    parent_return_status.merge(is_violation)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,14 @@ impl ReturnStatus {
             ReturnStatus::Violation => ExitCode::FAILURE,
         }
     }
+
+    pub fn merge(self, has_violation: bool) -> Self {
+        if has_violation || matches!(self, Self::Violation) {
+            Self::Violation
+        } else {
+            Self::NoViolation
+        }
+    }
 }
 
 pub fn handler(


### PR DESCRIPTION
## Summary
- `ReturnStatus` に `merge(self, has_violation: bool)` メソッドを追加
- `tree.rs` 内の4箇所の同一 match パターンを `merge()` 呼び出しに置換

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — 全テスト通過

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)