### PR TITLE
fix: correct CI workflow push trigger path

### DIFF
--- a/.github/workflows/ci-check-test.yaml
+++ b/.github/workflows/ci-check-test.yaml
@@ -7,7 +7,7 @@ on:
       - '**/*.rs'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
-      - '.github/workflows/ci.yaml'
+      - '.github/workflows/ci-check-test.yaml'
 
   pull_request:
     paths:


### PR DESCRIPTION
## Summary
- `.github/workflows/ci-check-test.yaml` の push トリガーパスが存在しない `ci.yaml` を参照していたのを `ci-check-test.yaml` に修正

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)