### PR TITLE
refactor: move from_file from DependencyRule to DependencyRules

### DIFF
--- a/src/dependency_rule/mod.rs
+++ b/src/dependency_rule/mod.rs
@@ -22,7 +22,9 @@ impl DependencyRule {
             forbidden_dependencies,
         }
     }
+}
 
+impl DependencyRules {
     pub(crate) fn from_file<P>(path: P) -> Result<DependencyRules, Error>
     where
         P: AsRef<std::path::Path>,
@@ -57,7 +59,7 @@ mod tests {
             }],
         };
 
-        let actual = DependencyRule::from_file(path).unwrap();
+        let actual = DependencyRules::from_file(path).unwrap();
         assert_eq!(expected, actual);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub fn handler(
         .parent()
         .ok_or_else(|| anyhow::anyhow!("manifest path has no parent directory"))?;
     let rules =
-        dependency_rule::DependencyRule::from_file(rules_dir.join("dependency_rules.toml"))?;
+        dependency_rule::DependencyRules::from_file(rules_dir.join("dependency_rules.toml"))?;
 
     dependency_graph::tree::print(
         &graph,


### PR DESCRIPTION
## Summary
- `DependencyRule::from_file()` が `DependencyRules`（複数形）を返していたため、`DependencyRules` の関連関数に移動
- `src/lib.rs` の呼び出し箇所も `DependencyRules::from_file(...)` に更新

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)