### PR TITLE
feat: add clap CLI argument parsing

### DIFF
--- a/src/dependency_graph/tree.rs
+++ b/src/dependency_graph/tree.rs
@@ -11,7 +11,7 @@ use petgraph::visit::EdgeRef;
 use std::collections::HashSet;
 use std::io::Write;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, clap::ValueEnum)]
 pub enum Prefix {
     None,
     Indent,
@@ -39,6 +39,7 @@ static ASCII_SYMBOLS: Symbols = Symbols {
     right: "-",
 };
 
+#[derive(Clone, Copy, clap::ValueEnum)]
 pub enum Charset {
     Utf8,
     Ascii,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,79 +26,84 @@ impl ReturnStatus {
     }
 }
 
-pub fn handler(
-    graph_build_configs: dependency_graph::DependencyGraphBuildConfigs,
-    metadata_configs: metadata::CollectMetadataConfig,
-) -> anyhow::Result<ReturnStatus> {
-    let metadata = metadata::collect_metadata(metadata_configs.clone())?;
-    let graph = dependency_graph::build_dependency_graph(metadata.clone(), graph_build_configs)?;
+pub struct HandlerConfig {
+    pub graph_build_configs: dependency_graph::DependencyGraphBuildConfigs,
+    pub metadata_configs: metadata::CollectMetadataConfig,
+    pub tree_config: dependency_graph::tree::TreePrintConfig,
+    pub rules_path: Option<PathBuf>,
+}
 
-    let manifest_path = match metadata_configs.manifest_path {
-        Some(path) => PathBuf::from(path),
-        None => env::current_dir()?.join("Cargo.toml"),
+pub fn handler(config: HandlerConfig) -> anyhow::Result<ReturnStatus> {
+    let metadata = metadata::collect_metadata(config.metadata_configs.clone())?;
+    let graph =
+        dependency_graph::build_dependency_graph(metadata.clone(), config.graph_build_configs)?;
+
+    let rules_path = match config.rules_path {
+        Some(path) => path,
+        None => {
+            let manifest_path = match config.metadata_configs.manifest_path {
+                Some(path) => PathBuf::from(path),
+                None => env::current_dir()?.join("Cargo.toml"),
+            };
+            let rules_dir = manifest_path
+                .parent()
+                .ok_or_else(|| anyhow::anyhow!("manifest path has no parent directory"))?;
+            rules_dir.join("dependency_rules.toml")
+        }
     };
-    let rules_dir = manifest_path
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("manifest path has no parent directory"))?;
-    let rules =
-        dependency_rule::DependencyRules::from_file(rules_dir.join("dependency_rules.toml"))?;
+    let rules = dependency_rule::DependencyRules::from_file(rules_path)?;
 
     dependency_graph::tree::print(
         &mut std::io::stdout(),
         &graph,
         &metadata,
         rules,
-        dependency_graph::tree::TreePrintConfig::default(),
+        config.tree_config,
     )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{dependency_graph::DependencyGraphBuildConfigs, metadata::CollectMetadataConfig};
+    use crate::{
+        dependency_graph::{DependencyGraphBuildConfigs, tree::TreePrintConfig},
+        metadata::CollectMetadataConfig,
+    };
     use anyhow::Result;
+
+    fn handler_config(manifest_path: &str) -> HandlerConfig {
+        HandlerConfig {
+            graph_build_configs: DependencyGraphBuildConfigs::default(),
+            metadata_configs: CollectMetadataConfig {
+                manifest_path: Some(manifest_path.to_string()),
+                ..CollectMetadataConfig::default()
+            },
+            tree_config: TreePrintConfig::default(),
+            rules_path: None,
+        }
+    }
 
     #[test]
     #[ignore]
     fn test_main() -> Result<()> {
-        let build_config = DependencyGraphBuildConfigs::default();
-        let collect_metadata_config = CollectMetadataConfig {
-            manifest_path: Some("tests/demo_crates/clean-arch/Cargo.toml".to_string()),
-            ..CollectMetadataConfig::default()
-        };
-
-        let _ = handler(build_config, collect_metadata_config)?;
-
+        let config = handler_config("tests/demo_crates/clean-arch/Cargo.toml");
+        let _ = handler(config)?;
         Ok(())
     }
 
     #[test]
     fn test_handler_success() -> Result<()> {
-        let expected_return_code = ExitCode::SUCCESS;
-        let build_config = DependencyGraphBuildConfigs::default();
-        let collect_metadata_config = CollectMetadataConfig {
-            manifest_path: Some("tests/demo_crates/clean-arch/Cargo.toml".to_string()),
-            ..CollectMetadataConfig::default()
-        };
-
-        let result = handler(build_config, collect_metadata_config)?;
-        assert_eq!(result.to_return_code(), expected_return_code);
-
+        let config = handler_config("tests/demo_crates/clean-arch/Cargo.toml");
+        let result = handler(config)?;
+        assert_eq!(result.to_return_code(), ExitCode::SUCCESS);
         Ok(())
     }
 
     #[test]
     fn test_handler_failure() -> Result<()> {
-        let expected_return_code = ExitCode::FAILURE;
-        let build_config = DependencyGraphBuildConfigs::default();
-        let collect_metadata_config = CollectMetadataConfig {
-            manifest_path: Some("tests/demo_crates/tangled-clean-arch/Cargo.toml".to_string()),
-            ..CollectMetadataConfig::default()
-        };
-
-        let result = handler(build_config, collect_metadata_config)?;
-        assert_eq!(result.to_return_code(), expected_return_code);
-
+        let config = handler_config("tests/demo_crates/tangled-clean-arch/Cargo.toml");
+        let result = handler(config)?;
+        assert_eq!(result.to_return_code(), ExitCode::FAILURE);
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,61 @@
-use std::process::ExitCode;
+use std::{path::PathBuf, process::ExitCode};
 
 use anyhow::{Ok, Result};
 use check_deprule::{
-    dependency_graph::DependencyGraphBuildConfigs, handler, metadata::CollectMetadataConfig,
+    HandlerConfig,
+    dependency_graph::{
+        DependencyGraphBuildConfigs,
+        tree::{Charset, Prefix, TreePrintConfig},
+    },
+    handler,
+    metadata::CollectMetadataConfig,
 };
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(
+    name = "check-deprule",
+    about = "Lint dependency constraints in Cargo workspaces"
+)]
+struct Cli {
+    /// Path to Cargo.toml
+    #[arg(long)]
+    manifest_path: Option<String>,
+
+    /// Path to dependency_rules.toml
+    #[arg(long)]
+    rules_path: Option<PathBuf>,
+
+    /// Exclude dev-dependencies from the graph
+    #[arg(long)]
+    no_dev_dependencies: bool,
+
+    /// Tree character set
+    #[arg(long, value_enum, default_value_t = Charset::Utf8)]
+    charset: Charset,
+
+    /// Tree prefix style
+    #[arg(long, value_enum, default_value_t = Prefix::Indent)]
+    prefix: Prefix,
+}
 
 fn main() -> Result<ExitCode> {
-    let build_config = DependencyGraphBuildConfigs::default();
-    let collect_metadata_config = CollectMetadataConfig {
-        manifest_path: None,
-        ..CollectMetadataConfig::default()
+    let cli = Cli::parse();
+
+    let config = HandlerConfig {
+        graph_build_configs: DependencyGraphBuildConfigs::new(cli.no_dev_dependencies),
+        metadata_configs: CollectMetadataConfig {
+            manifest_path: cli.manifest_path,
+            ..CollectMetadataConfig::default()
+        },
+        tree_config: TreePrintConfig {
+            charset: cli.charset,
+            prefix: cli.prefix,
+        },
+        rules_path: cli.rules_path,
     };
 
-    let result = handler(build_config, collect_metadata_config)?;
+    let result = handler(config)?;
 
     Ok(result.to_return_code())
 }


### PR DESCRIPTION
## Summary
- clap derive マクロで CLI 引数パースを追加 (`--manifest-path`, `--rules-path`, `--no-dev-dependencies`, `--charset`, `--prefix`)
- `Charset`, `Prefix` に `clap::ValueEnum` を derive
- `HandlerConfig` 構造体を導入し、handler のパラメータを整理
- `--rules-path` でルールファイルのパスを直接指定可能に

Closes #95

## Test plan
- [x] `cargo fmt --check` — OK
- [x] `cargo clippy -- -D warnings` — OK
- [x] `cargo test` — 32 passed
- [x] `cargo run -- --help` — CLI ヘルプ出力確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)