### PR TITLE
feat: integrate tracing for structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "check-deprule"
 version = "0.0.3"
 dependencies = [
@@ -106,6 +121,7 @@ dependencies = [
  "string-auto-indent",
  "toml",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -303,16 +319,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "line-ending"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "834e592123b39b7b3ba3fdc4b7e4822fad3ced449010f8229f843fe6dd1a33f1"
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "once_cell"
@@ -361,6 +407,23 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "semver"
@@ -425,6 +488,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "string-auto-indent"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +546,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -540,6 +627,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -553,6 +670,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 toml = "0.8.20"
 tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 [dev-dependencies]
 string-auto-indent = "0.1.2"

--- a/src/dependency_graph/mod.rs
+++ b/src/dependency_graph/mod.rs
@@ -27,6 +27,7 @@ impl DependencyGraphBuildConfigs {
     }
 }
 
+#[tracing::instrument(skip(metadata), fields(packages = metadata.packages.len()))]
 pub fn build_dependency_graph(
     metadata: Metadata,
     config: DependencyGraphBuildConfigs,

--- a/src/dependency_rule/mod.rs
+++ b/src/dependency_rule/mod.rs
@@ -25,6 +25,7 @@ impl DependencyRule {
 }
 
 impl DependencyRules {
+    #[tracing::instrument(skip_all, fields(path = ?path.as_ref()))]
     pub(crate) fn from_file<P>(path: P) -> Result<DependencyRules, Error>
     where
         P: AsRef<std::path::Path>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,10 @@ pub struct HandlerConfig {
 }
 
 pub fn handler(config: HandlerConfig) -> anyhow::Result<ReturnStatus> {
+    tracing::info!("collecting cargo metadata");
     let metadata = metadata::collect_metadata(config.metadata_configs.clone())?;
+
+    tracing::info!("building dependency graph");
     let graph =
         dependency_graph::build_dependency_graph(metadata.clone(), config.graph_build_configs)?;
 
@@ -51,8 +54,10 @@ pub fn handler(config: HandlerConfig) -> anyhow::Result<ReturnStatus> {
             rules_dir.join("dependency_rules.toml")
         }
     };
+    tracing::info!(path = ?rules_path, "loading dependency rules");
     let rules = dependency_rule::DependencyRules::from_file(rules_path)?;
 
+    tracing::info!("printing dependency tree");
     dependency_graph::tree::print(
         &mut std::io::stdout(),
         &graph,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use check_deprule::{
     metadata::CollectMetadataConfig,
 };
 use clap::Parser;
+use tracing::info;
 
 #[derive(Parser)]
 #[command(
@@ -37,10 +38,27 @@ struct Cli {
     /// Tree prefix style
     #[arg(long, value_enum, default_value_t = Prefix::Indent)]
     prefix: Prefix,
+
+    /// Log level (overridden by RUST_LOG env var)
+    #[arg(long, default_value = "warn")]
+    log_level: tracing::Level,
 }
 
 fn main() -> Result<ExitCode> {
     let cli = Cli::parse();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(cli.log_level.as_str())),
+        )
+        .init();
+
+    info!(
+        manifest_path = ?cli.manifest_path,
+        no_dev_dependencies = cli.no_dev_dependencies,
+        "starting check-deprule"
+    );
 
     let config = HandlerConfig {
         graph_build_configs: DependencyGraphBuildConfigs::new(cli.no_dev_dependencies),

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -40,6 +40,7 @@ impl Default for CollectMetadataConfig {
     }
 }
 
+#[tracing::instrument(skip_all, fields(manifest_path = ?config.manifest_path))]
 pub fn collect_metadata(config: CollectMetadataConfig) -> Result<Metadata, Error> {
     let cargo = env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
 


### PR DESCRIPTION
## Summary
- `tracing-subscriber` (env-filter) を追加し、構造化ログを導入
- `--log-level` CLI オプション追加 (デフォルト: warn、`RUST_LOG` 環境変数で上書き可能)
- `build_dependency_graph`, `collect_metadata`, `DependencyRules::from_file` に `#[tracing::instrument]` を追加
- `handler` の各ステップに `tracing::info!` ログを追加

Closes #88

## Test plan
- [x] `cargo fmt --check` — OK
- [x] `cargo clippy -- -D warnings` — OK
- [x] `cargo test` — 32 passed
- [x] `RUST_LOG=info cargo run` でログ出力確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)