### PR TITLE
refactor: separate violation detection from tree output

### DIFF
--- a/src/dependency_graph/mod.rs
+++ b/src/dependency_graph/mod.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 pub(crate) mod formatter;
 pub mod tree;
+pub mod violation;
 
 #[derive(Debug, Clone)]
 pub struct Graph {

--- a/src/dependency_graph/tree.rs
+++ b/src/dependency_graph/tree.rs
@@ -1,6 +1,5 @@
-use crate::ReturnStatus;
 use crate::dependency_graph::formatter::Chunk;
-use crate::dependency_rule::DependencyRules;
+use crate::dependency_graph::violation::ViolationReport;
 
 use super::Graph;
 use super::formatter::Pattern;
@@ -88,7 +87,7 @@ struct TreePrinter<'a, W: Write> {
     symbols: &'static Symbols,
     prefix: Prefix,
     all: bool,
-    rules: &'a DependencyRules,
+    report: &'a ViolationReport,
     visited_deps: HashSet<&'a PackageId>,
     levels_continue: Vec<bool>,
 }
@@ -97,7 +96,7 @@ impl<'a, W: Write> TreePrinter<'a, W> {
     fn new(
         writer: W,
         graph: &'a Graph,
-        rules: &'a DependencyRules,
+        report: &'a ViolationReport,
         config: TreePrintConfig,
     ) -> Result<Self, Error> {
         Ok(Self {
@@ -108,24 +107,23 @@ impl<'a, W: Write> TreePrinter<'a, W> {
             symbols: config.charset.symbols(),
             prefix: config.prefix,
             all: true,
-            rules,
+            report,
             visited_deps: HashSet::new(),
             levels_continue: vec![],
         })
     }
 
-    fn print_root(&mut self, root: &'a Package) -> Result<ReturnStatus, Error> {
+    fn print_root(&mut self, root: &'a Package) -> Result<(), Error> {
         self.visited_deps.clear();
         self.levels_continue.clear();
-        self.print_package(None, root, ReturnStatus::NoViolation)
+        self.print_package(None, root)
     }
 
     fn print_package(
         &mut self,
         parent_package: Option<&'a Package>,
         package: &'a Package,
-        parent_return_status: ReturnStatus,
-    ) -> Result<ReturnStatus, Error> {
+    ) -> Result<(), Error> {
         let new = self.all || self.visited_deps.insert(&package.id);
 
         match self.prefix {
@@ -149,20 +147,10 @@ impl<'a, W: Write> TreePrinter<'a, W> {
         }
 
         let star = if new { "" } else { " (*)" };
-        let mut is_violation = {
-            self.rules.rules.iter().any(|rule| {
-                if let Some(parent_package) = parent_package {
-                    rule.package
-                        == PackageId {
-                            repr: parent_package.name.clone(),
-                        }
-                        && rule.forbidden_dependencies.contains(&PackageId {
-                            repr: package.name.clone(),
-                        })
-                } else {
-                    false
-                }
-            })
+        let is_violation = if let Some(parent) = parent_package {
+            self.report.is_violation(&parent.name, &package.name)
+        } else {
+            false
         };
         match is_violation {
             true => {
@@ -173,7 +161,7 @@ impl<'a, W: Write> TreePrinter<'a, W> {
         };
 
         if !new {
-            return Ok(parent_return_status.merge(is_violation));
+            return Ok(());
         }
 
         for kind in &[
@@ -181,24 +169,17 @@ impl<'a, W: Write> TreePrinter<'a, W> {
             DependencyKind::Build,
             DependencyKind::Development,
         ] {
-            let current_return_status = parent_return_status.clone().merge(is_violation);
-
-            let result = self.print_dependencies(package, *kind, current_return_status)?;
-
-            if let ReturnStatus::Violation = result {
-                is_violation = true;
-            }
+            self.print_dependencies(package, *kind)?;
         }
 
-        Ok(parent_return_status.merge(is_violation))
+        Ok(())
     }
 
     fn print_dependencies(
         &mut self,
         package: &'a Package,
         kind: DependencyKind,
-        parent_return_status: ReturnStatus,
-    ) -> Result<ReturnStatus, Error> {
+    ) -> Result<(), Error> {
         let idx = self.graph.nodes[&package.id];
         let mut deps = vec![];
         for edge in self.graph.graph.edges_directed(idx, self.direction) {
@@ -215,7 +196,7 @@ impl<'a, W: Write> TreePrinter<'a, W> {
         }
 
         if deps.is_empty() {
-            return Ok(parent_return_status);
+            return Ok(());
         }
 
         // ensure a consistent output ordering
@@ -239,25 +220,14 @@ impl<'a, W: Write> TreePrinter<'a, W> {
             writeln!(self.writer, "{name}")?;
         }
 
-        let mut is_violation = false;
         let mut it = deps.iter().peekable();
         while let Some(dependency) = it.next() {
             self.levels_continue.push(it.peek().is_some());
-            let current_return_status = if is_violation {
-                ReturnStatus::Violation
-            } else {
-                parent_return_status.clone()
-            };
-
-            let result = self.print_package(Some(package), dependency, current_return_status)?;
-
+            self.print_package(Some(package), dependency)?;
             self.levels_continue.pop();
-            if let ReturnStatus::Violation = result {
-                is_violation = true;
-            }
         }
 
-        Ok(parent_return_status.merge(is_violation))
+        Ok(())
     }
 }
 
@@ -265,11 +235,10 @@ pub fn print(
     writer: &mut impl Write,
     graph: &Graph,
     metadata: &Metadata,
-    rules: DependencyRules,
+    report: &ViolationReport,
     config: TreePrintConfig,
-) -> Result<ReturnStatus, Error> {
-    let mut printer = TreePrinter::new(writer, graph, &rules, config)?;
-    let mut return_status = ReturnStatus::NoViolation;
+) -> Result<(), Error> {
+    let mut printer = TreePrinter::new(writer, graph, report, config)?;
 
     for member_id in &metadata.workspace_members {
         let idx = graph.nodes.get(member_id).ok_or_else(|| {
@@ -277,19 +246,16 @@ pub fn print(
         })?;
         let root = &graph.graph[*idx];
 
-        let result = printer.print_root(root)?;
-
-        if let ReturnStatus::Violation = result {
-            return_status = ReturnStatus::Violation
-        }
+        printer.print_root(root)?;
     }
 
-    Ok(return_status)
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dependency_graph::violation::check_violations;
     use crate::dependency_graph::{DependencyGraphBuildConfigs, build_dependency_graph};
     use crate::dependency_rule::DependencyRules;
     use crate::metadata::{CollectMetadataConfig, collect_metadata};
@@ -306,18 +272,19 @@ mod tests {
             build_dependency_graph(metadata.clone(), DependencyGraphBuildConfigs::default())?;
         let rules =
             DependencyRules::from_file("tests/demo_crates/clean-arch/dependency_rules.toml")?;
+        let report = check_violations(&graph, &rules);
 
         let mut buf = Vec::new();
-        let result = print(
+        print(
             &mut buf,
             &graph,
             &metadata,
-            rules,
+            &report,
             TreePrintConfig::default(),
         )?;
 
         assert!(!buf.is_empty());
-        assert!(matches!(result, ReturnStatus::NoViolation));
+        assert!(!report.has_violations());
         Ok(())
     }
 
@@ -333,18 +300,19 @@ mod tests {
         let rules = DependencyRules::from_file(
             "tests/demo_crates/tangled-clean-arch/dependency_rules.toml",
         )?;
+        let report = check_violations(&graph, &rules);
 
         let mut buf = Vec::new();
-        let result = print(
+        print(
             &mut buf,
             &graph,
             &metadata,
-            rules,
+            &report,
             TreePrintConfig::default(),
         )?;
 
         assert!(!buf.is_empty());
-        assert!(matches!(result, ReturnStatus::Violation));
+        assert!(report.has_violations());
         Ok(())
     }
 
@@ -359,13 +327,14 @@ mod tests {
             build_dependency_graph(metadata.clone(), DependencyGraphBuildConfigs::default())?;
         let rules =
             DependencyRules::from_file("tests/demo_crates/clean-arch/dependency_rules.toml")?;
+        let report = check_violations(&graph, &rules);
 
         let mut buf = Vec::new();
         print(
             &mut buf,
             &graph,
             &metadata,
-            rules,
+            &report,
             TreePrintConfig::default(),
         )?;
 
@@ -386,13 +355,14 @@ mod tests {
             build_dependency_graph(metadata.clone(), DependencyGraphBuildConfigs::default())?;
         let rules =
             DependencyRules::from_file("tests/demo_crates/clean-arch/dependency_rules.toml")?;
+        let report = check_violations(&graph, &rules);
 
         let mut buf = Vec::new();
         let tree_config = TreePrintConfig {
             charset: Charset::Ascii,
             prefix: Prefix::Indent,
         };
-        print(&mut buf, &graph, &metadata, rules, tree_config)?;
+        print(&mut buf, &graph, &metadata, &report, tree_config)?;
 
         let output = String::from_utf8(buf)?;
         assert!(output.contains("|--"), "ASCII tree should contain |--");
@@ -410,13 +380,14 @@ mod tests {
             build_dependency_graph(metadata.clone(), DependencyGraphBuildConfigs::default())?;
         let rules =
             DependencyRules::from_file("tests/demo_crates/clean-arch/dependency_rules.toml")?;
+        let report = check_violations(&graph, &rules);
 
         let mut buf = Vec::new();
         let tree_config = TreePrintConfig {
             charset: Charset::Utf8,
             prefix: Prefix::Depth,
         };
-        print(&mut buf, &graph, &metadata, rules, tree_config)?;
+        print(&mut buf, &graph, &metadata, &report, tree_config)?;
 
         let output = String::from_utf8(buf)?;
         assert!(
@@ -437,13 +408,14 @@ mod tests {
             build_dependency_graph(metadata.clone(), DependencyGraphBuildConfigs::default())?;
         let rules =
             DependencyRules::from_file("tests/demo_crates/clean-arch/dependency_rules.toml")?;
+        let report = check_violations(&graph, &rules);
 
         let mut buf = Vec::new();
         let tree_config = TreePrintConfig {
             charset: Charset::Utf8,
             prefix: Prefix::None,
         };
-        print(&mut buf, &graph, &metadata, rules, tree_config)?;
+        print(&mut buf, &graph, &metadata, &report, tree_config)?;
 
         let output = String::from_utf8(buf)?;
         assert!(

--- a/src/dependency_graph/violation.rs
+++ b/src/dependency_graph/violation.rs
@@ -1,0 +1,141 @@
+use super::Graph;
+use crate::dependency_rule::DependencyRules;
+use cargo_metadata::PackageId;
+use petgraph::visit::{EdgeRef, IntoEdgeReferences};
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Violation {
+    pub parent: String,
+    pub dependency: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ViolationReport {
+    pub violations: Vec<Violation>,
+    violated_edges: HashSet<(String, String)>,
+}
+
+impl ViolationReport {
+    pub fn is_violation(&self, parent_name: &str, dependency_name: &str) -> bool {
+        self.violated_edges
+            .contains(&(parent_name.to_string(), dependency_name.to_string()))
+    }
+
+    pub fn has_violations(&self) -> bool {
+        !self.violations.is_empty()
+    }
+}
+
+#[tracing::instrument(skip_all)]
+pub fn check_violations(graph: &Graph, rules: &DependencyRules) -> ViolationReport {
+    let mut violations = Vec::new();
+    let mut violated_edges = HashSet::new();
+
+    for edge in graph.graph.edge_references() {
+        let parent = &graph.graph[edge.source()];
+        let child = &graph.graph[edge.target()];
+
+        let is_forbidden = rules.rules.iter().any(|rule| {
+            rule.package
+                == PackageId {
+                    repr: parent.name.clone(),
+                }
+                && rule.forbidden_dependencies.contains(&PackageId {
+                    repr: child.name.clone(),
+                })
+        });
+
+        if is_forbidden && violated_edges.insert((parent.name.clone(), child.name.clone())) {
+            violations.push(Violation {
+                parent: parent.name.clone(),
+                dependency: child.name.clone(),
+            });
+        }
+    }
+
+    ViolationReport {
+        violations,
+        violated_edges,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dependency_graph::{DependencyGraphBuildConfigs, build_dependency_graph};
+    use crate::dependency_rule::DependencyRules;
+    use crate::metadata::{CollectMetadataConfig, collect_metadata};
+    use anyhow::Result;
+
+    #[test]
+    fn test_check_violations_no_violation() -> Result<()> {
+        let config = CollectMetadataConfig {
+            manifest_path: Some("tests/demo_crates/clean-arch/Cargo.toml".to_string()),
+            ..CollectMetadataConfig::default()
+        };
+        let metadata = collect_metadata(config)?;
+        let graph = build_dependency_graph(metadata, DependencyGraphBuildConfigs::default())?;
+        let rules =
+            DependencyRules::from_file("tests/demo_crates/clean-arch/dependency_rules.toml")?;
+
+        let report = check_violations(&graph, &rules);
+
+        assert!(!report.has_violations());
+        assert!(report.violations.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_check_violations_with_violation() -> Result<()> {
+        let config = CollectMetadataConfig {
+            manifest_path: Some("tests/demo_crates/tangled-clean-arch/Cargo.toml".to_string()),
+            ..CollectMetadataConfig::default()
+        };
+        let metadata = collect_metadata(config)?;
+        let graph = build_dependency_graph(metadata, DependencyGraphBuildConfigs::default())?;
+        let rules = DependencyRules::from_file(
+            "tests/demo_crates/tangled-clean-arch/dependency_rules.toml",
+        )?;
+
+        let report = check_violations(&graph, &rules);
+
+        assert!(report.has_violations());
+        assert!(!report.violations.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_check_violations_is_violation_lookup() -> Result<()> {
+        let config = CollectMetadataConfig {
+            manifest_path: Some("tests/demo_crates/tangled-clean-arch/Cargo.toml".to_string()),
+            ..CollectMetadataConfig::default()
+        };
+        let metadata = collect_metadata(config)?;
+        let graph = build_dependency_graph(metadata, DependencyGraphBuildConfigs::default())?;
+        let rules = DependencyRules::from_file(
+            "tests/demo_crates/tangled-clean-arch/dependency_rules.toml",
+        )?;
+
+        let report = check_violations(&graph, &rules);
+
+        // At least one violation should be detectable via is_violation
+        let has_lookup_match = report
+            .violations
+            .iter()
+            .any(|v| report.is_violation(&v.parent, &v.dependency));
+        assert!(has_lookup_match);
+
+        // Non-existent edge should not be a violation
+        assert!(!report.is_violation("nonexistent-pkg", "another-pkg"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_report_default() {
+        let report = ViolationReport::default();
+        assert!(!report.has_violations());
+        assert!(report.violations.is_empty());
+        assert!(!report.is_violation("any", "pkg"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,14 +16,6 @@ impl ReturnStatus {
             ReturnStatus::Violation => ExitCode::FAILURE,
         }
     }
-
-    pub fn merge(self, has_violation: bool) -> Self {
-        if has_violation || matches!(self, Self::Violation) {
-            Self::Violation
-        } else {
-            Self::NoViolation
-        }
-    }
 }
 
 pub struct HandlerConfig {
@@ -57,14 +49,23 @@ pub fn handler(config: HandlerConfig) -> anyhow::Result<ReturnStatus> {
     tracing::info!(path = ?rules_path, "loading dependency rules");
     let rules = dependency_rule::DependencyRules::from_file(rules_path)?;
 
+    tracing::info!("checking violations");
+    let report = dependency_graph::violation::check_violations(&graph, &rules);
+
     tracing::info!("printing dependency tree");
     dependency_graph::tree::print(
         &mut std::io::stdout(),
         &graph,
         &metadata,
-        rules,
+        &report,
         config.tree_config,
-    )
+    )?;
+
+    if report.has_violations() {
+        Ok(ReturnStatus::Violation)
+    } else {
+        Ok(ReturnStatus::NoViolation)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- `ViolationReport` / `Violation` 構造体と `check_violations` 関数を新規追加 (`violation.rs`)
- `TreePrinter` から `DependencyRules` を除去し、`ViolationReport` を消費する形に変更
- ツリー走査中の `ReturnStatus` 伝搬を除去し、違反判定は事前計算済みの `ViolationReport` から O(1) で参照
- `ReturnStatus::merge` を未使用のため削除
- 違反検出の単独テスト 4件を追加 (計 33→37 テスト)

Closes #97

## Test plan

- [x] `cargo fmt --check` パス
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo build` パス
- [x] `cargo test` パス (37テスト全通過)
- [x] 既存の clean-arch (違反なし) / tangled-clean-arch (違反あり) テストケースで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)