### PR TITLE
fix: improve error messages when loading dependency rules

### DIFF
--- a/src/dependency_rule/mod.rs
+++ b/src/dependency_rule/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{Error, Ok};
+use anyhow::{Context, Error};
 use cargo_metadata::PackageId;
 use std::{collections::HashSet, fs};
 mod rules_parser;
@@ -30,10 +30,16 @@ impl DependencyRules {
     where
         P: AsRef<std::path::Path>,
     {
-        let rules_text: String = fs::read_to_string(path)?;
-        let rules: RulesFileSchema = toml::from_str(&rules_text)?;
+        let path = path.as_ref();
+        let rules_text: String = fs::read_to_string(path).with_context(|| {
+            format!("failed to read dependency rules from '{}'", path.display())
+        })?;
+        let rules: RulesFileSchema = toml::from_str(&rules_text)
+            .with_context(|| format!("failed to parse dependency rules in '{}'", path.display()))?;
 
-        Ok(rules.try_into()?)
+        rules
+            .try_into()
+            .with_context(|| format!("invalid dependency rules in '{}'", path.display()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use std::{env, path::PathBuf, process::ExitCode};
 
 pub mod dependency_graph;
@@ -47,7 +48,12 @@ pub fn handler(config: HandlerConfig) -> anyhow::Result<ReturnStatus> {
         }
     };
     tracing::info!(path = ?rules_path, "loading dependency rules");
-    let rules = dependency_rule::DependencyRules::from_file(rules_path)?;
+    let rules = dependency_rule::DependencyRules::from_file(&rules_path).with_context(|| {
+        format!(
+            "failed to load dependency rules from '{}'",
+            rules_path.display()
+        )
+    })?;
 
     tracing::info!("checking violations");
     let report = dependency_graph::violation::check_violations(&graph, &rules);


### PR DESCRIPTION
## Summary
- `from_file` 内の各ステップに `.with_context()` でファイルパスを含むエラーメッセージを付与
  - ファイル読み込み失敗: `failed to read dependency rules from '...'`
  - TOML パース失敗: `failed to parse dependency rules in '...'`
  - バリデーション失敗: `invalid dependency rules in '...'`
- `lib.rs` の呼び出し元にも `.with_context()` を追加
- 未使用の `anyhow::Ok` インポートを削除

## Test plan
- [x] `cargo fmt --check` パス
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo test` 全48テスト成功

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)