### PR TITLE
refactor: replace PackageId with String in DependencyRule

### DIFF
--- a/src/dependency_graph/violation.rs
+++ b/src/dependency_graph/violation.rs
@@ -1,6 +1,5 @@
 use super::Graph;
 use crate::dependency_rule::DependencyRules;
-use cargo_metadata::PackageId;
 use petgraph::visit::{EdgeRef, IntoEdgeReferences};
 use std::collections::HashSet;
 
@@ -37,13 +36,7 @@ pub fn check_violations(graph: &Graph, rules: &DependencyRules) -> ViolationRepo
         let child = &graph.graph[edge.target()];
 
         let is_forbidden = rules.rules.iter().any(|rule| {
-            rule.package
-                == PackageId {
-                    repr: parent.name.clone(),
-                }
-                && rule.forbidden_dependencies.contains(&PackageId {
-                    repr: child.name.clone(),
-                })
+            rule.package == parent.name && rule.forbidden_dependencies.contains(&child.name)
         });
 
         if is_forbidden && violated_edges.insert((parent.name.clone(), child.name.clone())) {
@@ -64,7 +57,7 @@ pub fn check_violations(graph: &Graph, rules: &DependencyRules) -> ViolationRepo
 mod tests {
     use super::*;
     use crate::dependency_graph::{DependencyGraphBuildConfigs, build_dependency_graph};
-    use crate::dependency_rule::{DependencyRule, DependencyRules};
+    use crate::dependency_rule::DependencyRules;
     use crate::metadata::{CollectMetadataConfig, collect_metadata};
     use anyhow::Result;
 
@@ -167,13 +160,9 @@ mod tests {
 
         // グラフに存在しないパッケージ名のルール
         let rules = DependencyRules {
-            rules: vec![DependencyRule::new(
-                PackageId {
-                    repr: "nonexistent-package".to_string(),
-                },
-                std::collections::HashSet::from([PackageId {
-                    repr: "also-nonexistent".to_string(),
-                }]),
+            rules: vec![crate::dependency_rule::DependencyRule::new(
+                "nonexistent-package".to_string(),
+                HashSet::from(["also-nonexistent".to_string()]),
             )],
         };
 

--- a/src/dependency_rule/mod.rs
+++ b/src/dependency_rule/mod.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Error};
-use cargo_metadata::PackageId;
 use std::{collections::HashSet, fs};
 mod rules_parser;
 
@@ -12,11 +11,11 @@ pub struct DependencyRules {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct DependencyRule {
-    pub(crate) package: PackageId,
-    pub(crate) forbidden_dependencies: HashSet<PackageId>,
+    pub(crate) package: String,
+    pub(crate) forbidden_dependencies: HashSet<String>,
 }
 impl DependencyRule {
-    pub(crate) fn new(package: PackageId, forbidden_dependencies: HashSet<PackageId>) -> Self {
+    pub(crate) fn new(package: String, forbidden_dependencies: HashSet<String>) -> Self {
         Self {
             package,
             forbidden_dependencies,
@@ -52,16 +51,10 @@ mod tests {
         let path = "tests/test_files/parse_rules_test.toml";
         let expected = DependencyRules {
             rules: vec![DependencyRule {
-                package: PackageId {
-                    repr: "package1".to_string(),
-                },
-                forbidden_dependencies: HashSet::from_iter([
-                    PackageId {
-                        repr: "package2".to_string(),
-                    },
-                    PackageId {
-                        repr: "package3".to_string(),
-                    },
+                package: "package1".to_string(),
+                forbidden_dependencies: HashSet::from([
+                    "package2".to_string(),
+                    "package3".to_string(),
                 ]),
             }],
         };

--- a/src/dependency_rule/rules_parser.rs
+++ b/src/dependency_rule/rules_parser.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 
 use super::{DependencyRule, DependencyRules};
 use anyhow::{Error, bail};
-use cargo_metadata::PackageId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -22,18 +21,10 @@ impl TryFrom<RulesFileSchema> for DependencyRules {
 
         let dependency_rules = rules
             .rule
-            .iter()
+            .into_iter()
             .map(|rule| {
-                let package = PackageId {
-                    repr: rule.package.clone(),
-                };
-                let forbidden_dependencies = HashSet::from_iter(
-                    rule.forbidden_dependencies
-                        .iter()
-                        .map(|p| PackageId { repr: p.clone() }),
-                );
-
-                DependencyRule::new(package, forbidden_dependencies)
+                let forbidden_dependencies = HashSet::from_iter(rule.forbidden_dependencies);
+                DependencyRule::new(rule.package, forbidden_dependencies)
             })
             .collect();
 
@@ -103,17 +94,8 @@ mod tests {
         };
         let expected = DependencyRules {
             rules: vec![DependencyRule::new(
-                PackageId {
-                    repr: "package1".to_string(),
-                },
-                HashSet::from([
-                    PackageId {
-                        repr: "package2".to_string(),
-                    },
-                    PackageId {
-                        repr: "package3".to_string(),
-                    },
-                ]),
+                "package1".to_string(),
+                HashSet::from(["package2".to_string(), "package3".to_string()]),
             )],
         };
 


### PR DESCRIPTION
## Summary
- `DependencyRule` のフィールドを `PackageId` から `String` に変更
- `violation.rs` の比較で `PackageId { repr: name.clone() }` 構築を廃止し、名前ベースで直接比較
- `rules_parser.rs` で `PackageId` 変換を削除、`into_iter` で所有権移動による不要な clone 削減
- `cargo_metadata::PackageId` の内部表現 (`repr`) への依存を解消

## Test plan
- [x] `cargo fmt --check` パス
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo test` 全48テスト成功

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)