### PR TITLE
refactor: change build_dependency_graph to take &Metadata

### DIFF
--- a/src/dependency_graph/mod.rs
+++ b/src/dependency_graph/mod.rs
@@ -30,39 +30,40 @@ impl DependencyGraphBuildConfigs {
 
 #[tracing::instrument(skip(metadata), fields(packages = metadata.packages.len()))]
 pub fn build_dependency_graph(
-    metadata: Metadata,
+    metadata: &Metadata,
     config: DependencyGraphBuildConfigs,
 ) -> Result<Graph, Error> {
     let resolve = metadata
         .resolve
+        .as_ref()
         .ok_or_else(|| anyhow!("cargo metadata did not return dependency resolve information"))?;
 
     let mut graph = Graph {
         graph: StableGraph::new(),
         nodes: HashMap::new(),
-        root: resolve.root,
+        root: resolve.root.clone(),
     };
 
-    for package in metadata.packages {
+    for package in &metadata.packages {
         let id = package.id.clone();
-        let index = graph.graph.add_node(package);
+        let index = graph.graph.add_node(package.clone());
         graph.nodes.insert(id, index);
     }
 
-    for node in resolve.nodes {
+    for node in &resolve.nodes {
         if node.deps.len() != node.dependencies.len() {
             return Err(anyhow!("cargo tree requires cargo 1.41 or newer"));
         }
 
         let from = graph.nodes[&node.id];
-        for dep in node.deps {
+        for dep in &node.deps {
             if dep.dep_kinds.is_empty() {
                 return Err(anyhow!("cargo tree requires cargo 1.41 or newer"));
             }
 
             // https://github.com/rust-lang/cargo/issues/7752
             let mut kinds = vec![];
-            for kind in dep.dep_kinds {
+            for kind in &dep.dep_kinds {
                 if !kinds.contains(&kind.kind) {
                     kinds.push(kind.kind);
                 }
@@ -115,7 +116,7 @@ mod tests {
     fn test_build_dependency_graph_creates_nodes() -> Result<()> {
         let metadata = clean_arch_metadata()?;
         let workspace_count = metadata.workspace_members.len();
-        let graph = build_dependency_graph(metadata, DependencyGraphBuildConfigs::default())?;
+        let graph = build_dependency_graph(&metadata, DependencyGraphBuildConfigs::default())?;
 
         assert!(graph.nodes.len() >= workspace_count);
         Ok(())
@@ -124,10 +125,9 @@ mod tests {
     #[test]
     fn test_build_dependency_graph_workspace_members_present() -> Result<()> {
         let metadata = clean_arch_metadata()?;
-        let member_ids: Vec<_> = metadata.workspace_members.clone();
-        let graph = build_dependency_graph(metadata, DependencyGraphBuildConfigs::default())?;
+        let graph = build_dependency_graph(&metadata, DependencyGraphBuildConfigs::default())?;
 
-        for id in &member_ids {
+        for id in &metadata.workspace_members {
             assert!(
                 graph.nodes.contains_key(id),
                 "missing workspace member: {id}"
@@ -140,10 +140,10 @@ mod tests {
     fn test_build_dependency_graph_no_dev_dependencies() -> Result<()> {
         let metadata = clean_arch_metadata()?;
         let config_with_dev = DependencyGraphBuildConfigs::new(false);
-        let graph_with_dev = build_dependency_graph(metadata.clone(), config_with_dev)?;
+        let graph_with_dev = build_dependency_graph(&metadata, config_with_dev)?;
 
         let config_no_dev = DependencyGraphBuildConfigs::new(true);
-        let graph_no_dev = build_dependency_graph(metadata, config_no_dev)?;
+        let graph_no_dev = build_dependency_graph(&metadata, config_no_dev)?;
 
         assert!(
             graph_no_dev.graph.edge_count() <= graph_with_dev.graph.edge_count(),

--- a/src/dependency_graph/tree.rs
+++ b/src/dependency_graph/tree.rs
@@ -268,8 +268,7 @@ mod tests {
             ..CollectMetadataConfig::default()
         };
         let metadata = collect_metadata(config)?;
-        let graph =
-            build_dependency_graph(metadata.clone(), DependencyGraphBuildConfigs::default())?;
+        let graph = build_dependency_graph(&metadata, DependencyGraphBuildConfigs::default())?;
         let rules =
             DependencyRules::from_file("tests/demo_crates/clean-arch/dependency_rules.toml")?;
         let report = check_violations(&graph, &rules);
@@ -295,8 +294,7 @@ mod tests {
             ..CollectMetadataConfig::default()
         };
         let metadata = collect_metadata(config)?;
-        let graph =
-            build_dependency_graph(metadata.clone(), DependencyGraphBuildConfigs::default())?;
+        let graph = build_dependency_graph(&metadata, DependencyGraphBuildConfigs::default())?;
         let rules = DependencyRules::from_file(
             "tests/demo_crates/tangled-clean-arch/dependency_rules.toml",
         )?;
@@ -323,8 +321,7 @@ mod tests {
             ..CollectMetadataConfig::default()
         };
         let metadata = collect_metadata(config)?;
-        let graph =
-            build_dependency_graph(metadata.clone(), DependencyGraphBuildConfigs::default())?;
+        let graph = build_dependency_graph(&metadata, DependencyGraphBuildConfigs::default())?;
         let rules =
             DependencyRules::from_file("tests/demo_crates/clean-arch/dependency_rules.toml")?;
         let report = check_violations(&graph, &rules);
@@ -351,8 +348,7 @@ mod tests {
             ..CollectMetadataConfig::default()
         };
         let metadata = collect_metadata(config)?;
-        let graph =
-            build_dependency_graph(metadata.clone(), DependencyGraphBuildConfigs::default())?;
+        let graph = build_dependency_graph(&metadata, DependencyGraphBuildConfigs::default())?;
         let rules =
             DependencyRules::from_file("tests/demo_crates/clean-arch/dependency_rules.toml")?;
         let report = check_violations(&graph, &rules);
@@ -376,8 +372,7 @@ mod tests {
             ..CollectMetadataConfig::default()
         };
         let metadata = collect_metadata(config)?;
-        let graph =
-            build_dependency_graph(metadata.clone(), DependencyGraphBuildConfigs::default())?;
+        let graph = build_dependency_graph(&metadata, DependencyGraphBuildConfigs::default())?;
         let rules =
             DependencyRules::from_file("tests/demo_crates/clean-arch/dependency_rules.toml")?;
         let report = check_violations(&graph, &rules);
@@ -404,8 +399,7 @@ mod tests {
             ..CollectMetadataConfig::default()
         };
         let metadata = collect_metadata(config)?;
-        let graph =
-            build_dependency_graph(metadata.clone(), DependencyGraphBuildConfigs::default())?;
+        let graph = build_dependency_graph(&metadata, DependencyGraphBuildConfigs::default())?;
         let rules =
             DependencyRules::from_file("tests/demo_crates/clean-arch/dependency_rules.toml")?;
         let report = check_violations(&graph, &rules);

--- a/src/dependency_graph/violation.rs
+++ b/src/dependency_graph/violation.rs
@@ -68,7 +68,7 @@ mod tests {
             ..CollectMetadataConfig::default()
         };
         let metadata = collect_metadata(config)?;
-        let graph = build_dependency_graph(metadata, DependencyGraphBuildConfigs::default())?;
+        let graph = build_dependency_graph(&metadata, DependencyGraphBuildConfigs::default())?;
         let rules =
             DependencyRules::from_file("tests/demo_crates/clean-arch/dependency_rules.toml")?;
 
@@ -86,7 +86,7 @@ mod tests {
             ..CollectMetadataConfig::default()
         };
         let metadata = collect_metadata(config)?;
-        let graph = build_dependency_graph(metadata, DependencyGraphBuildConfigs::default())?;
+        let graph = build_dependency_graph(&metadata, DependencyGraphBuildConfigs::default())?;
         let rules = DependencyRules::from_file(
             "tests/demo_crates/tangled-clean-arch/dependency_rules.toml",
         )?;
@@ -105,7 +105,7 @@ mod tests {
             ..CollectMetadataConfig::default()
         };
         let metadata = collect_metadata(config)?;
-        let graph = build_dependency_graph(metadata, DependencyGraphBuildConfigs::default())?;
+        let graph = build_dependency_graph(&metadata, DependencyGraphBuildConfigs::default())?;
         let rules = DependencyRules::from_file(
             "tests/demo_crates/tangled-clean-arch/dependency_rules.toml",
         )?;
@@ -139,7 +139,7 @@ mod tests {
             ..CollectMetadataConfig::default()
         };
         let metadata = collect_metadata(config)?;
-        let graph = build_dependency_graph(metadata, DependencyGraphBuildConfigs::default())?;
+        let graph = build_dependency_graph(&metadata, DependencyGraphBuildConfigs::default())?;
         let rules = DependencyRules { rules: Vec::new() };
 
         let report = check_violations(&graph, &rules);
@@ -156,7 +156,7 @@ mod tests {
             ..CollectMetadataConfig::default()
         };
         let metadata = collect_metadata(config)?;
-        let graph = build_dependency_graph(metadata, DependencyGraphBuildConfigs::default())?;
+        let graph = build_dependency_graph(&metadata, DependencyGraphBuildConfigs::default())?;
 
         // グラフに存在しないパッケージ名のルール
         let rules = DependencyRules {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,7 @@ pub fn handler(config: HandlerConfig) -> anyhow::Result<ReturnStatus> {
     let metadata = metadata::collect_metadata(config.metadata_configs.clone())?;
 
     tracing::info!("building dependency graph");
-    let graph =
-        dependency_graph::build_dependency_graph(metadata.clone(), config.graph_build_configs)?;
+    let graph = dependency_graph::build_dependency_graph(&metadata, config.graph_build_configs)?;
 
     let rules_path = match config.rules_path {
         Some(path) => path,


### PR DESCRIPTION
## Summary
- `build_dependency_graph` のシグネチャを `metadata: Metadata` → `metadata: &Metadata` に変更
- `lib.rs` の `metadata.clone()` を削除（Metadata 全体の不要なクローンを解消）
- テスト内の `metadata.clone()` も削除
- 内部で必要な `packages` と `resolve` のみ個別に参照/クローン

## Test plan
- [x] `cargo fmt --check` パス
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo test` 全48テスト成功

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)