### PR TITLE
docs: update README remaining tasks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,9 @@ cargo install check-deprule
 check-deprule
 ```
 
-## remaining tasks
+## Roadmap
 
-- ルール定義ファイルの指定
 - ルールをパッケージ名だけではなく、柔軟に記載できるようにする
-- clapを使ったCLIアプリケーション化
-- 違反パッケージの特定とdependency treeの出力を分ける
 
 # Special Thanks
 - [cargo-tree](https://github.com/sfackler/cargo-tree/tree/master)


### PR DESCRIPTION
## Summary
- 実装済みの3項目を削除（ルールファイル指定、clap CLI化、違反検出分離）
- 未実装の「柔軟なルール記載」のみ残す
- セクション名を "remaining tasks" → "Roadmap" に変更

## Test plan
- [x] README.md の内容確認

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)